### PR TITLE
pining qiskit in setup.py simplyfies README a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ The flowchart can be edited within draw.io. The source can be found at https://d
 ```
 conda create --name quantum python=3.6
 conda activate quantum
-conda install numpy scipy cython ipython
-pip install qiskit==0.15.0
+conda install cython ipython
 git clone git@github.com:rsln-s/variationaltoolkit.git
 cd variationaltoolkit
 pip install -e .

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
 setup(name='variationaltoolkit',
-	description='a set of tools wrapping variational forms',
-	author='Ruslan Shaydulin',
-	author_email='rshaydu@g.clemson.edu',
-	packages=['variationaltoolkit'],
-    install_requires=['qiskit'],
-	zip_safe=False)
+      description='a set of tools wrapping variational forms',
+      author='Ruslan Shaydulin',
+      author_email='rshaydu@g.clemson.edu',
+      packages=['variationaltoolkit'],
+      install_requires=['qiskit==0.15'],
+      zip_safe=False)


### PR DESCRIPTION
By adding `install_requires=['qiskit==0.15']`, the Qiskit dependencies brings `numpy` and `scipy` with its. They are going to be installed at `pip install .` time. 